### PR TITLE
2021-10-07 GUARD-2171 Changed the OrderId type to string

### DIFF
--- a/WooCommerce.NET.csproj
+++ b/WooCommerce.NET.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <PackageId>WooCommerceNET.SV</PackageId>
-    <Version>1.1.6</Version>
+    <Version>1.2.6.0-alpha</Version>
     <Authors>SkuVault</Authors>
     <Company>SkuVault</Company>
     <Description>A .NET Wrapper for WooCommerce REST API. This is a fork of WooCommerce.NET downgraded to .NET Framework 4.6.1 and a number of issues fixed</Description>
@@ -19,10 +19,10 @@ Origin Changes Doc: https://github.com/XiaoFaye/WooCommerce.NET/blob/master/Chan
 * v0.7.6 update
   1. Supporting WooCommerce Restful API V3.</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.1.6.0</AssemblyVersion>
+    <AssemblyVersion>1.2.6.0</AssemblyVersion>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>sn.key.snk</AssemblyOriginatorKeyFile>
-    <FileVersion>1.1.6.0</FileVersion>
+    <FileVersion>1.2.6.0</FileVersion>
   </PropertyGroup>
 
 </Project>

--- a/WooCommerce/Legacy/Order.cs
+++ b/WooCommerce/Legacy/Order.cs
@@ -19,7 +19,7 @@ namespace WooCommerceNET.WooCommerce.Legacy
         /// read-only
         /// </summary>
         [DataMember(EmitDefaultValue = false)]
-        public int? id { get; set; }
+        public string id { get; set; }
 
         /// <summary>
         /// Order number 

--- a/WooCommerce/v2/Order.cs
+++ b/WooCommerce/v2/Order.cs
@@ -17,7 +17,7 @@ namespace WooCommerceNET.WooCommerce.v2
         /// read-only
         /// </summary>
         [DataMember(EmitDefaultValue = false)]
-        public int? id { get; set; }
+        public string id { get; set; }
 
         /// <summary>
         /// Parent order ID.


### PR DESCRIPTION
Had to change the type of the OrderId inside the WooCommerceOrder object because the client was trying to use some prefix that includes letters, so the Int type didn't make sense for this case.

[`GUARD-2171`](https://agileharbor.atlassian.net/browse/GUARD-2171)

