### PR TITLE
VT-6192 Updated field manage_stock

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,9 +10,9 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<AssemblyVersion>1.2.15.0</AssemblyVersion>
-		<FileVersion>1.2.15.0</FileVersion>
-		<Version>1.2.15.0</Version>
+		<AssemblyVersion>1.2.16.0</AssemblyVersion>
+		<FileVersion>1.2.16.0</FileVersion>
+		<Version>1.2.16.0</Version>
 		<Authors>SkuVault</Authors>
 		<Company>SkuVault, Inc.</Company>
 		<Copyright>Copyright © 2023 SkuVault, Inc.</Copyright>

--- a/src/WooCommerce.NET/WooCommerce/v3/Product.cs
+++ b/src/WooCommerce.NET/WooCommerce/v3/Product.cs
@@ -319,8 +319,16 @@ namespace WooCommerceNET.WooCommerce.v3
         /// <summary>
         /// Stock management at product level. Default is false.
         /// </summary>
-        [DataMember(EmitDefaultValue = false)]
-        public bool? manage_stock { get; set; }
+        [DataMember(EmitDefaultValue = false, Name = "manage_stock")]
+        private object manage_stockValue { get; set; }
+        
+        /// <summary>
+        /// Stock management at product level. Default is false.
+        /// When Manage stock is checked, string value "parent" will be given, otherwise, it will be bool value false.
+        /// The "parent" should appear in Variation object, however, when getting Products with variation SKU as parameter, 
+        /// variation object with "parent" value returned in product endpoints. That's why we have to set manage_stock type as object in Product object as well.
+        /// </summary>
+        public bool manage_stock => manage_stockValue?.ToString().ToLower() == "parent";
 
         [DataMember(EmitDefaultValue = false, Name = "stock_quantity")]
         private object stock_quantityValue { get; set; }

--- a/src/tests/WooCommerce.NET.Tests/DeserializationTests.cs
+++ b/src/tests/WooCommerce.NET.Tests/DeserializationTests.cs
@@ -26,7 +26,7 @@ namespace WooCommerce.NET.Tests
 			@"..\..\Files\ProductsJsonResponse_WhenDatesAreEmpty.json",
 			"0001-01-01T00:00:00",
 			TestName = "DeserializeJSon_ProductsHaveDateTimeMinValue_WhenDatesAreEmpty")]
-		public void DeserializeJson(string fileName, string expectedDateValue)
+		public void DateTimeDeserializeJson(string fileName, string expectedDateValue)
 		{
 			// arrange
 			var restApiV3 = new RestAPI("wp-json/wc/v3", "", "");
@@ -51,6 +51,33 @@ namespace WooCommerce.NET.Tests
 			Assert.That(products[0].images[0].date_created_gmt, Is.EqualTo(expectedDate));
 			Assert.That(products[0].images[0].date_modified, Is.EqualTo(expectedDate));
 			Assert.That(products[0].images[0].date_modified_gmt, Is.EqualTo(expectedDate));
+		}
+		
+		[TestCase(
+			@"..\..\Files\ProductsJsonResponse_WhenManageStockValueIsParent.json",
+			true,
+			TestName = "DeserializeJSon_ManageStockIsTrue_WhenManageStockValueIsParent")]
+		[TestCase(
+			@"..\..\Files\ProductsJsonResponse_WhenManageStockValueIsNull.json",
+			false,
+			TestName = "DeserializeJSon_ManageStockIsFalse_WhenManageStockValueIsNull")]
+		[TestCase(
+			@"..\..\Files\ProductsJsonResponse_WhenManageStockValueIsFalse.json",
+			false,
+			TestName = "DeserializeJSon_ManageStockIsFalse_WhenManageStockValueIsFalse")]
+		public void ManageStockDeserializeJson(string fileName, bool expectedManageStock)
+		{
+			// arrange
+			var restApiV3 = new RestAPI("wp-json/wc/v3", "", "");
+
+			var jsonResponse = File.ReadAllText(fileName);
+
+			// act
+			var products = restApiV3.DeserializeJSon<List<Product>>(jsonResponse);
+
+			// assert
+			Assert.That(products.Count, Is.EqualTo(1));
+			Assert.That(products[0].manage_stock, Is.EqualTo(expectedManageStock));
 		}
 	}
 }

--- a/src/tests/WooCommerce.NET.Tests/Files/ProductsJsonResponse_WhenManageStockValueIsFalse.json
+++ b/src/tests/WooCommerce.NET.Tests/Files/ProductsJsonResponse_WhenManageStockValueIsFalse.json
@@ -1,0 +1,103 @@
+[{
+    "id": 210292,
+    "name": "",
+    "slug": "",
+    "permalink": "",
+    "date_created": "2023-11-29T19:03:58",
+    "date_created_gmt": "2023-11-29T19:03:58",
+    "date_modified": "2023-11-29T19:03:58",
+    "date_modified_gmt": "2023-11-29T19:03:58",
+    "type": "simple",
+    "status": "private",
+    "featured": false,
+    "catalog_visibility": "hidden",
+    "description": "",
+    "short_description": "",
+    "sku": "S-160-035",
+    "price": "289",
+    "regular_price": "479",
+    "sale_price": "289",
+    "date_on_sale_from": "2023-11-29T19:03:58",
+    "date_on_sale_from_gmt": "2023-11-29T19:03:58",
+    "date_on_sale_to": "2023-11-29T19:03:58",
+    "date_on_sale_to_gmt": "2023-11-29T19:03:58",
+    "on_sale": true,
+    "purchasable": true,
+    "total_sales": 16,
+    "virtual": false,
+    "downloadable": false,
+    "downloads": [],
+    "download_limit": -1,
+    "download_expiry": -1,
+    "external_url": "",
+    "button_text": "",
+    "tax_status": "taxable",
+    "tax_class": "",
+    "manage_stock": false,
+    "stock_quantity": null,
+    "backorders": "no",
+    "backorders_allowed": false,
+    "backordered": false,
+    "low_stock_amount": null,
+    "sold_individually": false,
+    "weight": "",
+    "dimensions": {
+      "length": "",
+      "width": "",
+      "height": ""
+    },
+    "shipping_required": true,
+    "shipping_taxable": true,
+    "shipping_class": "",
+    "shipping_class_id": 0,
+    "reviews_allowed": true,
+    "average_rating": "0.00",
+    "rating_count": 0,
+    "upsell_ids": [],
+    "cross_sell_ids": [],
+    "parent_id": 0,
+    "purchase_note": "",
+    "categories": [],
+    "tags": [],
+    "images": [
+      {
+        "id": 979,
+        "date_created": "2023-11-29T19:03:58",
+        "date_created_gmt": "2023-11-29T19:03:58",
+        "date_modified": "2023-11-29T19:03:58",
+        "date_modified_gmt": "2023-11-29T19:03:58",
+        "src": "https://cbcpfa.com/wp-content/uploads/2018/03/ar-15-front-extended-take-down-pin-stainless-steel.jpg",
+        "name": "ar-15-front-extended-take-down-pin-stainless-steel",
+        "alt": "ar 15 front extended take down pin stainless steel"
+      }
+    ],
+    "attributes": [],
+    "default_attributes": [],
+    "variations": [],
+    "grouped_products": [],
+    "menu_order": 0,
+    "price_html": "",
+    "related_ids": [
+      194159,
+      261425,
+      194154,
+      650,
+      126881
+    ],
+    "meta_data": [],
+    "stock_status": "instock",
+    "has_options": false,
+    "aioseo_notices": [],
+    "_links": {
+      "self": [
+        {
+          "href": "https://cbcpfa.com/wp-json/wc/v3/products/210292"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://cbcpfa.com/wp-json/wc/v3/products"
+        }
+      ]
+    }
+  }]

--- a/src/tests/WooCommerce.NET.Tests/Files/ProductsJsonResponse_WhenManageStockValueIsNull.json
+++ b/src/tests/WooCommerce.NET.Tests/Files/ProductsJsonResponse_WhenManageStockValueIsNull.json
@@ -1,0 +1,103 @@
+[{
+    "id": 210292,
+    "name": "",
+    "slug": "",
+    "permalink": "",
+    "date_created": "2023-11-29T19:03:58",
+    "date_created_gmt": "2023-11-29T19:03:58",
+    "date_modified": "2023-11-29T19:03:58",
+    "date_modified_gmt": "2023-11-29T19:03:58",
+    "type": "simple",
+    "status": "private",
+    "featured": false,
+    "catalog_visibility": "hidden",
+    "description": "",
+    "short_description": "",
+    "sku": "S-160-035",
+    "price": "289",
+    "regular_price": "479",
+    "sale_price": "289",
+    "date_on_sale_from": "2023-11-29T19:03:58",
+    "date_on_sale_from_gmt": "2023-11-29T19:03:58",
+    "date_on_sale_to": "2023-11-29T19:03:58",
+    "date_on_sale_to_gmt": "2023-11-29T19:03:58",
+    "on_sale": true,
+    "purchasable": true,
+    "total_sales": 16,
+    "virtual": false,
+    "downloadable": false,
+    "downloads": [],
+    "download_limit": -1,
+    "download_expiry": -1,
+    "external_url": "",
+    "button_text": "",
+    "tax_status": "taxable",
+    "tax_class": "",
+    "manage_stock": null,
+    "stock_quantity": null,
+    "backorders": "no",
+    "backorders_allowed": false,
+    "backordered": false,
+    "low_stock_amount": null,
+    "sold_individually": false,
+    "weight": "",
+    "dimensions": {
+      "length": "",
+      "width": "",
+      "height": ""
+    },
+    "shipping_required": true,
+    "shipping_taxable": true,
+    "shipping_class": "",
+    "shipping_class_id": 0,
+    "reviews_allowed": true,
+    "average_rating": "0.00",
+    "rating_count": 0,
+    "upsell_ids": [],
+    "cross_sell_ids": [],
+    "parent_id": 0,
+    "purchase_note": "",
+    "categories": [],
+    "tags": [],
+    "images": [
+      {
+        "id": 979,
+        "date_created": "2023-11-29T19:03:58",
+        "date_created_gmt": "2023-11-29T19:03:58",
+        "date_modified": "2023-11-29T19:03:58",
+        "date_modified_gmt": "2023-11-29T19:03:58",
+        "src": "https://cbcpfa.com/wp-content/uploads/2018/03/ar-15-front-extended-take-down-pin-stainless-steel.jpg",
+        "name": "ar-15-front-extended-take-down-pin-stainless-steel",
+        "alt": "ar 15 front extended take down pin stainless steel"
+      }
+    ],
+    "attributes": [],
+    "default_attributes": [],
+    "variations": [],
+    "grouped_products": [],
+    "menu_order": 0,
+    "price_html": "",
+    "related_ids": [
+      194159,
+      261425,
+      194154,
+      650,
+      126881
+    ],
+    "meta_data": [],
+    "stock_status": "instock",
+    "has_options": false,
+    "aioseo_notices": [],
+    "_links": {
+      "self": [
+        {
+          "href": "https://cbcpfa.com/wp-json/wc/v3/products/210292"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://cbcpfa.com/wp-json/wc/v3/products"
+        }
+      ]
+    }
+  }]

--- a/src/tests/WooCommerce.NET.Tests/Files/ProductsJsonResponse_WhenManageStockValueIsParent.json
+++ b/src/tests/WooCommerce.NET.Tests/Files/ProductsJsonResponse_WhenManageStockValueIsParent.json
@@ -1,0 +1,103 @@
+[{
+    "id": 210292,
+    "name": "",
+    "slug": "",
+    "permalink": "",
+    "date_created": "2023-11-29T19:03:58",
+    "date_created_gmt": "2023-11-29T19:03:58",
+    "date_modified": "2023-11-29T19:03:58",
+    "date_modified_gmt": "2023-11-29T19:03:58",
+    "type": "simple",
+    "status": "private",
+    "featured": false,
+    "catalog_visibility": "hidden",
+    "description": "",
+    "short_description": "",
+    "sku": "S-160-035",
+    "price": "289",
+    "regular_price": "479",
+    "sale_price": "289",
+    "date_on_sale_from": "2023-11-29T19:03:58",
+    "date_on_sale_from_gmt": "2023-11-29T19:03:58",
+    "date_on_sale_to": "2023-11-29T19:03:58",
+    "date_on_sale_to_gmt": "2023-11-29T19:03:58",
+    "on_sale": true,
+    "purchasable": true,
+    "total_sales": 16,
+    "virtual": false,
+    "downloadable": false,
+    "downloads": [],
+    "download_limit": -1,
+    "download_expiry": -1,
+    "external_url": "",
+    "button_text": "",
+    "tax_status": "taxable",
+    "tax_class": "",
+    "manage_stock": "parent",
+    "stock_quantity": null,
+    "backorders": "no",
+    "backorders_allowed": false,
+    "backordered": false,
+    "low_stock_amount": null,
+    "sold_individually": false,
+    "weight": "",
+    "dimensions": {
+      "length": "",
+      "width": "",
+      "height": ""
+    },
+    "shipping_required": true,
+    "shipping_taxable": true,
+    "shipping_class": "",
+    "shipping_class_id": 0,
+    "reviews_allowed": true,
+    "average_rating": "0.00",
+    "rating_count": 0,
+    "upsell_ids": [],
+    "cross_sell_ids": [],
+    "parent_id": 0,
+    "purchase_note": "",
+    "categories": [],
+    "tags": [],
+    "images": [
+      {
+        "id": 979,
+        "date_created": "2023-11-29T19:03:58",
+        "date_created_gmt": "2023-11-29T19:03:58",
+        "date_modified": "2023-11-29T19:03:58",
+        "date_modified_gmt": "2023-11-29T19:03:58",
+        "src": "https://cbcpfa.com/wp-content/uploads/2018/03/ar-15-front-extended-take-down-pin-stainless-steel.jpg",
+        "name": "ar-15-front-extended-take-down-pin-stainless-steel",
+        "alt": "ar 15 front extended take down pin stainless steel"
+      }
+    ],
+    "attributes": [],
+    "default_attributes": [],
+    "variations": [],
+    "grouped_products": [],
+    "menu_order": 0,
+    "price_html": "",
+    "related_ids": [
+      194159,
+      261425,
+      194154,
+      650,
+      126881
+    ],
+    "meta_data": [],
+    "stock_status": "instock",
+    "has_options": false,
+    "aioseo_notices": [],
+    "_links": {
+      "self": [
+        {
+          "href": "https://cbcpfa.com/wp-json/wc/v3/products/210292"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://cbcpfa.com/wp-json/wc/v3/products"
+        }
+      ]
+    }
+  }]


### PR DESCRIPTION
# Description

Tickets: [VT-6192]

We have error of deserilization because we wait that field manage_stock will have bool value but value of this field can be 'parent' or false. So I updated way of deserilization for this field and added tests for different situations.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Functionality change (fix or feature that would cause existing functionality to work differently than before)
- [ ] Configuration change
- [ ] New / updated script
- [ ] Refactoring
- [ ] New tests to existing code

# PR Readiness Checklist

- [X] Followed [development conventions][1] to the best of my ability
- [X] Code is documented, particularly public interfaces and hard-to-understand areas
- [X] Tests are updated / added and all pass
- [X] Performed a self-review of my own code
- [X] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [X] Confluence documentation is updated, if needed
- [X] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[VT-6192]: https://agileharbor.atlassian.net/browse/VT-6192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ