### PR TITLE
VT-6192 WooCommerce: Error on The Full Inventory Sync

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,9 +10,9 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<AssemblyVersion>1.2.17.0</AssemblyVersion>
-		<FileVersion>1.2.17.0</FileVersion>
-		<Version>1.2.17.0</Version>
+		<AssemblyVersion>1.2.18.0</AssemblyVersion>
+		<FileVersion>1.2.18.0</FileVersion>
+		<Version>1.2.18.0</Version>
 		<Authors>SkuVault</Authors>
 		<Company>SkuVault, Inc.</Company>
 		<Copyright>Copyright © 2023 SkuVault, Inc.</Copyright>

--- a/src/WooCommerce.NET/WooCommerce/v3/Product.cs
+++ b/src/WooCommerce.NET/WooCommerce/v3/Product.cs
@@ -329,7 +329,7 @@ namespace WooCommerceNET.WooCommerce.v3
         /// variation object with "parent" value returned in product endpoints. That's why we have to set manage_stock type as object in Product object as well.
         /// For more information go to <see href="http://github.com/XiaoFaye/WooCommerce.NET/blob/03f6ac114c15c3f83f3c7dff3c03b61f41a33fa8/WooCommerce/v3/Product.cs#L260">link</see>
         /// </summary>
-        public bool manage_stock => manage_stockValue?.ToString().ToLower() == "parent" || manage_stockValue?.ToString().ToLower() == "true";
+        public bool manage_stock => manage_stockValue?.ToString().ToLower() == "true";
 
         [DataMember(EmitDefaultValue = false, Name = "stock_quantity")]
         private object stock_quantityValue { get; set; }


### PR DESCRIPTION
# Description

Tickets: [VT-6192]

Field manage_stock should be TRUE only if value is true. Other values like 'false' and 'parent' should be false.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Functionality change (fix or feature that would cause existing functionality to work differently than before)
- [ ] Configuration change
- [ ] New / updated script
- [ ] Refactoring
- [ ] New tests to existing code

# PR Readiness Checklist

- [X] Followed [development conventions][1] to the best of my ability
- [X] Code is documented, particularly public interfaces and hard-to-understand areas
- [X] Tests are updated / added and all pass
- [X] Performed a self-review of my own code
- [X] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [X] Confluence documentation is updated, if needed
- [X] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions
